### PR TITLE
Feature/versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+- Update notifications-python-client; this indirectly fixes a backwards incompatible change in PyJWT
+- Fix the Factory Boy dependency specification
+
 ## 0.2.0 (2021-04-29)
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ isort = "^4.3.21"
 flake8 = "^3.8.2"
 pre-commit = "^2.4.0"
 detect-secrets = "0.13.0"
-factory-boy = "^3.0"
+factory-boy = "^3.2.0"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ license = "BSD-2-Clause"
 [tool.poetry.dependencies]
 python = ">=3.6.1,<3.9"
 django = ">=2.2.12,<4.0"
-notifications-python-client = "5.4.1"
+notifications-python-client = "^6.1.0"
 
 [tool.poetry.dev-dependencies]
 black = "^19.10b0"


### PR DESCRIPTION
There's a backwards-incompatible change in PyJWT 2, https://github.com/jpadilla/pyjwt/issues/529. If a project doesn't have this pinned, then it could cause an error.

The underlying notifications-python-client library has fixed this. https://github.com/alphagov/notifications-python-client/blob/master/CHANGELOG.md#571