### PR TITLE
chore/extended supported python and django versions

### DIFF
--- a/.github/workflows/CI-tests.yml
+++ b/.github/workflows/CI-tests.yml
@@ -3,7 +3,7 @@ name: CI tests
 on: [push]
 
 env:
-  poetry-version: 1.1.2
+  poetry-version: 1.2.0
 
 jobs:
   lint:

--- a/.github/workflows/CI-tests.yml
+++ b/.github/workflows/CI-tests.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python "3.6"
         uses: actions/setup-python@v2
         with:
-          python-version: "3.6"
+          python-version: "3.9"
       - uses: pre-commit/action@v2.0.0
 
   build:
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
-        django-version: ["2.2.20", "3.1.8", "3.2", "4.1", "4.2"]
+        django-version: ["3.2", "4.1", "4.2"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
-        django-version: ["2.2.20", "3.1.8", "3.2", "4.1", "4.2"]
+        django-version: ["3.2", "4.1", "4.2"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/CI-tests.yml
+++ b/.github/workflows/CI-tests.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         django-version: ["3.2", "4.1", "4.2"]
     steps:
       - uses: actions/checkout@v2
@@ -49,7 +49,7 @@ jobs:
     needs: [build, lint]
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         django-version: ["3.2", "4.1", "4.2"]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/CI-tests.yml
+++ b/.github/workflows/CI-tests.yml
@@ -20,19 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        include:
-          - python-version: "3.9"
-            django-version: "2.2.20"
-          - python-version: "3.9"
-            django-version: "3.1.8"
-          - python-version: "3.6"
-            django-version: "3.2"
-          - python-version: "3.7"
-            django-version: "3.2"
-          - python-version: "3.8"
-            django-version: "3.2"
-          - python-version: "3.9"
-            django-version: "3.2"
+        python-version: ["3.9", "3.10", "3.11"]
+        django-version: ["2.2.20", "3.1.8", "3.2", "4.1", "4.2"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -60,19 +49,8 @@ jobs:
     needs: [build, lint]
     strategy:
       matrix:
-        include:
-          - python-version: "3.9"
-            django-version: "2.2.20"
-          - python-version: "3.9"
-            django-version: "3.1.8"
-          - python-version: "3.6"
-            django-version: "3.2"
-          - python-version: "3.7"
-            django-version: "3.2"
-          - python-version: "3.8"
-            django-version: "3.2"
-          - python-version: "3.9"
-            django-version: "3.2"
+        python-version: ["3.9", "3.10", "3.11"]
+        django-version: ["2.2.20", "3.1.8", "3.2", "4.1", "4.2"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/CI-tests.yml
+++ b/.github/workflows/CI-tests.yml
@@ -21,7 +21,10 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        django-version: ["3.2", "4.1", "4.2"]
+        django-version: ["3.2.9", "4.1.3", "4.2"]
+        exclude:
+            - django-version: "3.2"
+              python-version: "3.11"
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -50,7 +53,10 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        django-version: ["3.2", "4.1", "4.2"]
+        django-version: ["3.2.9", "4.1.3", "4.2"]
+        exclude:
+            - django-version: "3.2"
+              python-version: "3.11"
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/CI-tests.yml
+++ b/.github/workflows/CI-tests.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python "3.6"
-        uses: actions/setup-python@v2
+      - name: Set up Python "3.9"
+        uses: actions/setup-python@v4
         with:
           python-version: "3.9"
-      - uses: pre-commit/action@v2.0.0
+      - uses: pre-commit/action@v3.0.0
 
   build:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,19 @@
 repos:
   - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v4.3.15
+    rev: v5.12.0
     hooks:
       - id: isort
         language_version: python3.6
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.7
+  - repo: https://github.com/pycqa/flake8
+    rev: 5.0.4
     hooks:
       - id: flake8
         language_version: python3.6
   - repo: https://github.com/python/black
-    rev: 19.10b0
+    rev: 23.10.1
     hooks:
       - id: black
-        language_version: python3.6
+        language_version: python3.9
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v6.5.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pycqa/isort
-    rev: v5.12.0
+    rev: 5.12.0
     hooks:
       - id: isort
         language_version: python3.6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-  - repo: https://github.com/pre-commit/mirrors-isort
+  - repo: https://github.com/pycqa/isort
     rev: v5.12.0
     hooks:
       - id: isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,12 +3,12 @@ repos:
     rev: 5.12.0
     hooks:
       - id: isort
-        language_version: python3.6
+        language_version: python3.9
   - repo: https://github.com/pycqa/flake8
     rev: 5.0.4
     hooks:
       - id: flake8
-        language_version: python3.6
+        language_version: python3.9
   - repo: https://github.com/python/black
     rev: 23.10.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
     hooks:
       - id: prettier
   - repo: https://github.com/awebdeveloper/pre-commit-stylelint
-    sha: c4c991cd38b0218735858716b09924f8b20e3812
+    rev: c4c991cd38b0218735858716b09924f8b20e3812
     hooks:
       - id: stylelint
         additional_dependencies:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This is implemented as a custom Django email backend. It presents a similar inte
 
 django-gov-notify supports:
 
-- Python 3.6, 3.7, 3.8, 3.9, 3.10, 3.11
+- Python 3.8, 3.9, 3.10 and 3.11
 - Django 3.2, 4.1 and 4.2
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This is implemented as a custom Django email backend. It presents a similar inte
 django-gov-notify supports:
 
 - Python 3.6, 3.7, 3.8, 3.9, 3.10, 3.11
-- Django 2.2, 3.1, 3.2, 4.1 and 4.2
+- Django 3.2, 4.1 and 4.2
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ This is implemented as a custom Django email backend. It presents a similar inte
 
 django-gov-notify supports:
 
-- Python 3.6, 3.7, 3.8, and 3.9
-- Django 2.2, 3.1 and 3.2
+- Python 3.6, 3.7, 3.8, 3.9, 3.10, 3.11
+- Django 2.2, 3.1, 3.2, 4.1 and 4.2
 
 ## Installation
 

--- a/django_gov_notify/message.py
+++ b/django_gov_notify/message.py
@@ -6,7 +6,7 @@ from django.core.mail.message import EmailMessage
 
 
 class NotifyEmailMessage(EmailMessage):
-    """An email message that knows how to work with GOV.UK Notify templates. """
+    """An email message that knows how to work with GOV.UK Notify templates."""
 
     def __init__(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,6 @@ classifiers = [
     "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -41,5 +39,5 @@ detect-secrets = "1.4.0"
 factory-boy = "^3.2.0"
 
 [build-system]
-requires = ["poetry>=0.12"]
+requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,17 +17,21 @@ classifiers = [
     "Framework :: Django :: 2.2",
     "Framework :: Django :: 3.1",
     "Framework :: Django :: 3.2",
+    "Framework :: Django :: 4.1",
+    "Framework :: Django :: 4.2",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
 ]
 license = "BSD-2-Clause"
 
 [tool.poetry.dependencies]
-python = ">=3.6.1,<3.10"
-django = ">=2.2.12,<4.0"
+python = ">=3.8,<3.12"
+django = ">=2.2.12,<5.0"
 notifications-python-client = "^6.1.0"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-gov-notify"
-version = "0.3.0"
+version = "0.3.1"
 description = "A GOV.UK Notify flavoured Django email backend"
 authors = ["Nick Smith <nick.smith@torchbox.com>"]
 readme = "README.md"
@@ -14,8 +14,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Topic :: Communications :: Email",
     "Framework :: Django",
-    "Framework :: Django :: 2.2",
-    "Framework :: Django :: 3.1",
     "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
@@ -31,15 +29,15 @@ license = "BSD-2-Clause"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
-django = ">=2.2.12,<5.0"
-notifications-python-client = "^6.1.0"
+django = ">=3.2,<5.0"
+notifications-python-client = "^8.1.0"
 
 [tool.poetry.dev-dependencies]
-black = "^19.10b0"
-isort = "^4.3.21"
-flake8 = "^3.8.2"
-pre-commit = "^2.4.0"
-detect-secrets = "0.13.0"
+black = "^23.10.1"
+isort = "^5.12.0"
+flake8 = "^5.0.4"
+pre-commit = "^3.5.0"
+detect-secrets = "1.4.0"
 factory-boy = "^3.2.0"
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,5 +39,5 @@ detect-secrets = "1.4.0"
 factory-boy = "^3.2.0"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.2.0"]
 build-backend = "poetry.masonry.api"


### PR DESCRIPTION
I would like to extend the support for python to 3.11 and django to 4.2 so that we can use `django-gov-notify` in production