### PR TITLE
Prove that python 3.12 is supported

### DIFF
--- a/.github/workflows/CI-tests.yml
+++ b/.github/workflows/CI-tests.yml
@@ -20,49 +20,32 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
-        django-version: ["3.2.9", "4.1.3", "4.2"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        django-version: ["3.2.9", "4.1.3", "4.2", "5.0.2"]
         exclude:
-          - django-version: "3.2"
+          # Django too old
+          - django-version: "3.2.9"
             python-version: "3.11"
+          - django-version: "3.2.9"
+            python-version: "3.12"
+
+          # Django too new
+          - django-version: "5.0.2"
+            python-version: "3.8"
+          - django-version: "5.0.2"
+            python-version: "3.9"
+          - django-version: "5.0.2"
+            python-version: "3.10"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Cache Poetry virtual env
-        uses: actions/cache@v2
-        with:
-          path: .venv
-          key: ${{ runner.os }}-python-${{ matrix.python-version }}-django-${{ matrix.django-version }}-${{ hashFiles('pyproject.toml') }}
       - name: Run image
         uses: abatilo/actions-poetry@v2
         with:
           poetry-version: ${{ env.poetry-version }}
-      - name: Install packages
-        run: |
-          poetry config virtualenvs.in-project true
-          poetry install
-          poetry add django==${{ matrix.django-version }}
-          poetry show django
-
-  test:
-    runs-on: ubuntu-latest
-    needs: [build, lint]
-    strategy:
-      matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
-        django-version: ["3.2.9", "4.1.3", "4.2"]
-        exclude:
-          - django-version: "3.2"
-            python-version: "3.11"
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Cache Poetry virtual env
         uses: actions/cache@v2
         env:
@@ -70,11 +53,52 @@ jobs:
         with:
           path: .venv
           key: ${{ runner.os }}-python-${{ matrix.python-version }}-django-${{ matrix.django-version }}-${{ hashFiles('pyproject.toml') }}
+      - name: Install packages
+        run: |
+          poetry config virtualenvs.in-project true
+          poetry remove django
+          poetry add django==${{ matrix.django-version }} --python ${{ matrix.python-version }}
+          poetry install
+          poetry show django
+
+  test:
+    runs-on: ubuntu-latest
+    needs: [build, lint]
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        django-version: ["3.2.9", "4.1.3", "4.2", "5.0.2"]
+        exclude:
+          # Django too old
+          - django-version: "3.2.9"
+            python-version: "3.11"
+          - django-version: "3.2.9"
+            python-version: "3.12"
+
+          # Django too new
+          - django-version: "5.0.2"
+            python-version: "3.8"
+          - django-version: "5.0.2"
+            python-version: "3.9"
+          - django-version: "5.0.2"
+            python-version: "3.10"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Run image
         uses: abatilo/actions-poetry@v2.0.0
         with:
           poetry-version: ${{ env.poetry-version }}
+      - name: Cache Poetry virtual env
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-poetry-virtualenv
+        with:
+          path: .venv
+          key: ${{ runner.os }}-python-${{ matrix.python-version }}-django-${{ matrix.django-version }}-${{ hashFiles('pyproject.toml') }}
       - name: Test
         run: |
-          poetry run python -m django --version
           poetry run python runtests.py

--- a/.github/workflows/CI-tests.yml
+++ b/.github/workflows/CI-tests.yml
@@ -3,7 +3,7 @@ name: CI tests
 on: [push]
 
 env:
-  poetry-version: 1.2.0
+  poetry-version: 1.8.2
 
 jobs:
   lint:
@@ -26,9 +26,9 @@ jobs:
           - django-version: "3.2"
             python-version: "3.11"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Cache Poetry virtual env
@@ -37,10 +37,10 @@ jobs:
           path: .venv
           key: ${{ runner.os }}-python-${{ matrix.python-version }}-django-${{ matrix.django-version }}-${{ hashFiles('pyproject.toml') }}
       - name: Run image
-        uses: abatilo/actions-poetry@v2.0.0
+        uses: abatilo/actions-poetry@v2
         with:
           poetry-version: ${{ env.poetry-version }}
-      - name: Install Python packages
+      - name: Install packages
         run: |
           poetry config virtualenvs.in-project true
           poetry install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,11 @@ classifiers = [
 license = "BSD-2-Clause"
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.12"
-django = ">=3.2,<5.0"
+python = ">=3.8,<3.13"
+django = [
+    {version = ">=3.2", python = ">=3.8,<3.13"},
+    {version = ">=5.0", python = ">=3.10,<3.13"},
+]
 notifications-python-client = "^8.1.0"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,5 +39,5 @@ detect-secrets = "1.4.0"
 factory-boy = "^3.2.0"
 
 [build-system]
-requires = ["poetry-core>=1.2.0"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Our project depends on Python 3.12 but this package doesn't officially support it.

Add it to the build matrix and show that tests continue to pass.