### PR TITLE
Update Python & Django supported versions

### DIFF
--- a/.github/workflows/CI-tests.yml
+++ b/.github/workflows/CI-tests.yml
@@ -20,22 +20,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        django-version: ["3.2.9", "4.1.3", "4.2", "5.0.2"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        django-version: ["4.2.16", "5.0.9", "5.1.2"]
         exclude:
-          # Django too old
-          - django-version: "3.2.9"
-            python-version: "3.11"
-          - django-version: "3.2.9"
-            python-version: "3.12"
-
           # Django too new
-          - django-version: "5.0.2"
-            python-version: "3.8"
-          - django-version: "5.0.2"
+          - django-version: "5.0.9"
             python-version: "3.9"
-          - django-version: "5.0.2"
-            python-version: "3.10"
+          - django-version: "5.1.2"
+            python-version: "3.9"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -66,22 +58,14 @@ jobs:
     needs: [build, lint]
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        django-version: ["3.2.9", "4.1.3", "4.2", "5.0.2"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        django-version: ["4.2.16", "5.0.9", "5.1.2"]
         exclude:
-          # Django too old
-          - django-version: "3.2.9"
-            python-version: "3.11"
-          - django-version: "3.2.9"
-            python-version: "3.12"
-
           # Django too new
-          - django-version: "5.0.2"
-            python-version: "3.8"
-          - django-version: "5.0.2"
+          - django-version: "5.0.9"
             python-version: "3.9"
-          - django-version: "5.0.2"
-            python-version: "3.10"
+          - django-version: "5.1.2"
+            python-version: "3.9"
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix dependency specification to allow use with combinations of Django 4.2 and Python >= 3.10
+- Update supported versions of Django & Python
 
 ## 0.5.0 (2024-05-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix dependency specification to allow use with combinations of Django 4.2 and Python >= 3.10
+
 ## 0.5.0 (2024-05-02)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ This is implemented as a custom Django email backend. It presents a similar inte
 
 django-gov-notify supports:
 
-- Python 3.8, 3.9, 3.10 and 3.11
-- Django 3.2, 4.1 and 4.2
+- Python 3.9, 3.10, 3.11 and 3.12
+- Django 4.2, 5.0 and 5.1
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ license = "BSD-2-Clause"
 python = ">=3.8,<3.13"
 django = [
     {version = ">=3.2", python = ">=3.8,<3.13"},
-    {version = ">=5.0", python = ">=3.10,<3.13"},
+    {version = ">=4.2", python = ">=3.9,<3.13"},
 ]
 notifications-python-client = "^8.1.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,21 +14,20 @@ classifiers = [
     "Operating System :: OS Independent",
     "Topic :: Communications :: Email",
     "Framework :: Django",
-    "Framework :: Django :: 3.2",
-    "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
+    "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.1",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 license = "BSD-2-Clause"
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.13"
+python = ">=3.9,<3.13"
 django = [
-    {version = ">=3.2", python = ">=3.8,<3.13"},
     {version = ">=4.2", python = ">=3.9,<3.13"},
 ]
 notifications-python-client = "^8.1.0"


### PR DESCRIPTION
This PR updates the versions of Python and Django supported by this project so that:

1. Use of this project with a combination of Django 4.2 and Python >= 3.10 is possible (fixes https://github.com/nimasmi/django-gov-notify/issues/13)
1. Versions which have reached EOL are removed