### PR TITLE
WIP: Testing maintenance

### DIFF
--- a/.github/workflows/CI-tests.yml
+++ b/.github/workflows/CI-tests.yml
@@ -2,9 +2,6 @@ name: CI tests
 
 on: [push]
 
-env:
-  poetry-version: 1.8.5
-
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -58,7 +55,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    needs: [build, lint]
+    needs: lint
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
@@ -80,6 +77,15 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Cache tox environments
+        uses: actions/cache@v4
+        with:
+          path: .tox
+          key: ${{ runner.os }}-tox-py${{ matrix.python-version }}-django${{ matrix.django-version }}-${{ hashFiles('pyproject.toml', 'tox.ini') }}
+          restore-keys: |
+            ${{ runner.os }}-tox-py${{ matrix.python-version }}-django${{ matrix.django-version }}-
+            ${{ runner.os }}-tox-py${{ matrix.python-version }}-
+            ${{ runner.os }}-tox-
       - name: Install tox and tox-gh-actions
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/CI-tests.yml
+++ b/.github/workflows/CI-tests.yml
@@ -28,6 +28,9 @@ jobs:
             python-version: "3.9"
           - django-version: "5.2"
             python-version: "3.9"
+          # Django too old
+          - django-version: "4.2"
+            python-version: "3.13"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/CI-tests.yml
+++ b/.github/workflows/CI-tests.yml
@@ -72,23 +72,17 @@ jobs:
           # Django too old
           - django-version: "4.2"
             python-version: "3.13"
+    env:
+      DJANGO: ${{ matrix.django-version }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Run image
-        uses: abatilo/actions-poetry@v4
-        with:
-          poetry-version: ${{ env.poetry-version }}
-      - name: Cache Poetry virtual env
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-poetry-virtualenv
-        with:
-          path: .venv
-          key: ${{ runner.os }}-python-${{ matrix.python-version }}-django-${{ matrix.django-version }}-${{ hashFiles('pyproject.toml') }}
-      - name: Test
+      - name: Install tox and tox-gh-actions
         run: |
-          poetry run python runtests.py
+          python -m pip install --upgrade pip
+          pip install tox tox-gh-actions
+      - name: Test with tox
+        run: tox

--- a/.github/workflows/CI-tests.yml
+++ b/.github/workflows/CI-tests.yml
@@ -66,6 +66,9 @@ jobs:
             python-version: "3.9"
           - django-version: "5.2"
             python-version: "3.9"
+          # Django too old
+          - django-version: "4.2"
+            python-version: "3.13"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/CI-tests.yml
+++ b/.github/workflows/CI-tests.yml
@@ -3,7 +3,7 @@ name: CI tests
 on: [push]
 
 env:
-  poetry-version: 1.8.2
+  poetry-version: 1.8.5
 
 jobs:
   lint:
@@ -20,13 +20,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
-        django-version: ["4.2.16", "5.0.9", "5.1.2"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        django-version: ["4.2", "5.1", "5.2"]
         exclude:
           # Django too new
-          - django-version: "5.0.9"
+          - django-version: "5.1"
             python-version: "3.9"
-          - django-version: "5.1.2"
+          - django-version: "5.2"
             python-version: "3.9"
     steps:
       - uses: actions/checkout@v4
@@ -35,7 +35,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run image
-        uses: abatilo/actions-poetry@v2
+        uses: abatilo/actions-poetry@v4
         with:
           poetry-version: ${{ env.poetry-version }}
       - name: Cache Poetry virtual env
@@ -58,13 +58,13 @@ jobs:
     needs: [build, lint]
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
-        django-version: ["4.2.16", "5.0.9", "5.1.2"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        django-version: ["4.2", "5.1", "5.2"]
         exclude:
           # Django too new
-          - django-version: "5.0.9"
+          - django-version: "5.1"
             python-version: "3.9"
-          - django-version: "5.1.2"
+          - django-version: "5.2"
             python-version: "3.9"
     steps:
       - uses: actions/checkout@v4
@@ -73,7 +73,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run image
-        uses: abatilo/actions-poetry@v2.0.0
+        uses: abatilo/actions-poetry@v4
         with:
           poetry-version: ${{ env.poetry-version }}
       - name: Cache Poetry virtual env

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ wheels/
 *.egg
 builds/
 poetry.lock
+.tox

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,16 @@
 repos:
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 6.0.1
     hooks:
       - id: isort
         language_version: python3.9
   - repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
+    rev: 7.3.0
     hooks:
       - id: flake8
         language_version: python3.9
   - repo: https://github.com/python/black
-    rev: 23.10.1
+    rev: 25.1.0
     hooks:
       - id: black
         language_version: python3.9
@@ -19,7 +19,7 @@ repos:
     hooks:
       - id: prettier
   - repo: https://github.com/Yelp/detect-secrets
-    rev: v0.13.0
+    rev: v1.5.0
     hooks:
       - id: detect-secrets
         args: ["--baseline", ".secrets.baseline"]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,8 +1,4 @@
 {
-  "exclude": {
-    "files": null,
-    "lines": null
-  },
   "generated_at": "2020-05-29T17:40:29Z",
   "plugins_used": [
     {
@@ -12,15 +8,15 @@
       "name": "ArtifactoryDetector"
     },
     {
-      "base64_limit": 4.5,
-      "name": "Base64HighEntropyString"
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
     },
     {
       "name": "BasicAuthDetector"
     },
     {
-      "hex_limit": 3,
-      "name": "HexHighEntropyString"
+      "name": "HexHighEntropyString",
+      "limit": 3
     },
     {
       "name": "JwtTokenDetector"
@@ -48,16 +44,49 @@
   "results": {
     "poetry.lock": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "poetry.lock",
         "hashed_secret": "ad21572f9e3b4576a754f88e9873b445e8bb0660",
         "is_verified": false,
-        "line_number": 494,
-        "type": "Hex High Entropy String"
+        "line_number": 494
       }
     ]
   },
-  "version": "0.13.0",
-  "word_list": {
-    "file": null,
-    "hash": null
-  }
+  "version": "1.5.0",
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    }
+  ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 0.6.0 (2024-10-25)
 
+## Unreleased
+
+- Support Python 3.13
+- Support Django 5.2
+- Drop support for Django 5.0
+- Add tox configuration for testing
+
 ### Features
 
 - Drop support for Python 3.8

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ This is implemented as a custom Django email backend. It presents a similar inte
 
 django-gov-notify supports:
 
-- Python 3.9, 3.10, 3.11 and 3.12
-- Django 4.2, 5.0 and 5.1
+- Python 3.9, 3.10, 3.11, 3.12 and 3.13
+- Django 4.2, 5.1 and 5.2
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,30 +15,29 @@ classifiers = [
     "Topic :: Communications :: Email",
     "Framework :: Django",
     "Framework :: Django :: 4.2",
-    "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 license = "BSD-2-Clause"
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.13"
-django = [
-    {version = ">=4.2", python = ">=3.9,<3.13"},
-]
+python = ">=3.9"
+django = ">=4.2"
 notifications-python-client = "^8.1.0"
 
 [tool.poetry.dev-dependencies]
-black = "^23.10.1"
-isort = "^5.12.0"
-flake8 = "^5.0.4"
-pre-commit = "^3.5.0"
-detect-secrets = "1.4.0"
-factory-boy = "^3.2.0"
+black = "^25.1.0"
+isort = "^6.0.1"
+flake8 = "^7.3.0"
+pre-commit = "^4.2.0"
+detect-secrets = "1.5.0"
+factory-boy = "^3.3.3"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -40,7 +40,7 @@ STATIC_URL = "/static/"
 MEDIA_ROOT = os.path.join(BASE_DIR, "test-media")
 MEDIA_URL = "http://media.example.com/media/"
 
-SECRET_KEY = "not needed"
+SECRET_KEY = "not needed"  # pragma: allowlist secret
 
-GOVUK_NOTIFY_API_KEY = "not a real API key"
+GOVUK_NOTIFY_API_KEY = "not a real API key"  # pragma: allowlist secret
 GOVUK_NOTIFY_PLAIN_EMAIL_TEMPLATE_ID = str(uuid.uuid4())

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -14,7 +14,9 @@ class EmailBackendTest(TestCase):
     def setUp(self):
         self.backend = NotifyEmailBackend(govuk_notify_api_key="not a real key")
 
-    @override_settings(GOVUK_NOTIFY_API_KEY="fake settings key")
+    @override_settings(
+        GOVUK_NOTIFY_API_KEY="fake settings key"  # pragma: allowlist secret
+    )
     def test_default_key(self, mock_client):
         backend = NotifyEmailBackend()
         self.assertEqual(backend.api_key, "fake settings key")

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,20 @@ envlist =
 minversion = 4.0
 isolated_build = true
 
+[gh-actions]
+python =
+    3.9: py39
+    3.10: py310
+    3.11: py311
+    3.12: py312
+    3.13: py313
+
+[gh-actions:env]
+DJANGO =
+    4.2: django42
+    5.1: django51
+    5.2: django52
+
 [testenv]
 deps =
     django42: django>=4.2,<5.0
@@ -17,6 +31,27 @@ deps =
     notifications-python-client>=8.1.0
     factory-boy>=3.3.3
 commands = python runtests.py {posargs}
+
+[testenv:lint]
+deps =
+    black>=25.1.0
+    isort>=6.0.1
+    flake8>=7.3.0
+    pre-commit>=4.2.0
+    detect-secrets==1.5.0
+commands =
+    black --check --diff .
+    isort --check-only --diff .
+    flake8 .
+    detect-secrets scan
+
+[testenv:format]
+deps =
+    black>=25.1.0
+    isort>=6.0.1
+commands =
+    black .
+    isort .
 
 [flake8]
 max-line-length = 88

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,29 @@
+[tox]
+envlist =
+    py39-django42
+    py310-django{42,51,52}
+    py311-django{42,51,52}
+    py312-django{42,51,52}
+    py313-django{51,52}
+    lint
+minversion = 4.0
+isolated_build = true
+
+[testenv]
+deps =
+    django42: django>=4.2,<5.0
+    django51: django>=5.1,<5.2
+    django52: django>=5.2,<5.3
+    notifications-python-client>=8.1.0
+    factory-boy>=3.3.3
+commands = python runtests.py {posargs}
+
+[flake8]
+max-line-length = 88
+extend-ignore = E203, W503
+exclude = .git,__pycache__,build,dist,.tox,.venv,venv
+
+[tool:isort]
+profile = black
+multi_line_output = 3
+line_length = 88

--- a/tox.ini
+++ b/tox.ini
@@ -32,26 +32,23 @@ deps =
     factory-boy>=3.3.3
 commands = python runtests.py {posargs}
 
-[testenv:lint]
+[testenv:lint] # run with `tox -e lint`
 deps =
     black>=25.1.0
     isort>=6.0.1
     flake8>=7.3.0
-    pre-commit>=4.2.0
-    detect-secrets==1.5.0
 commands =
-    black --check --diff .
-    isort --check-only --diff .
+    black --check --diff --exclude=".tox" .
+    isort --check-only --diff --skip=.tox .
     flake8 .
-    detect-secrets scan
 
-[testenv:format]
+[testenv:format] # run with `tox -e format`
 deps =
     black>=25.1.0
     isort>=6.0.1
 commands =
-    black .
-    isort .
+    black --exclude=".tox" .
+    isort --skip=.tox .
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
See: https://github.com/torchbox-forks/django-gov-notify/pull/1 for tests in actions

This will:

- add support for Python 3.13 and Django 5.2
- add Tox for testing
- updates dependencies and configurations

### CI/CD and Testing
* Replaced Poetry with Tox for testing, adding a `tox.ini` file with configurations for different Python and Django versions. Updated GitHub Actions workflows to use Tox and simplified the CI pipeline.

### Dependency Updates
* Upgraded `.pre-commit-config.yaml` dependencies

### Secret Management Improvements
* Updated test files to explicitly allowlist secrets using `# pragma: allowlist secret` this was needed because detect-secrest has been upgraded.