### PR TITLE
chore: Remove front-end linters from pre-commit

### DIFF
--- a/.github/workflows/CI-tests.yml
+++ b/.github/workflows/CI-tests.yml
@@ -9,12 +9,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python "3.9"
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
-      - uses: pre-commit/action@v3.0.0
+      - uses: pre-commit/action@v3.0.1
 
   build:
     runs-on: ubuntu-latest
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run image
@@ -39,7 +39,7 @@ jobs:
         with:
           poetry-version: ${{ env.poetry-version }}
       - name: Cache Poetry virtual env
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-poetry-virtualenv
         with:
@@ -67,9 +67,9 @@ jobs:
           - django-version: "5.1.2"
             python-version: "3.9"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run image
@@ -77,7 +77,7 @@ jobs:
         with:
           poetry-version: ${{ env.poetry-version }}
       - name: Cache Poetry virtual env
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-poetry-virtualenv
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,34 +14,10 @@ repos:
     hooks:
       - id: black
         language_version: python3.9
-  - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v6.5.1
-    hooks:
-      - id: eslint
-        additional_dependencies:
-          - eslint@6.5.1
-          - eslint-config-airbnb@18.0.1
-          - eslint-config-prettier@6.4.0
-          - eslint-config-torchbox@0.3.1
-          - eslint-plugin-import@2.18.2
-          - eslint-plugin-jsx-a11y@6.2.3
-          - eslint-plugin-react@7.16.0
-          - eslint-plugin-react-hooks@1.7.0
-          - "@babel/core@7.5.0"
-          - "@babel/preset-env@7.5.0"
-          - "@babel/preset-react@7.0.0"
-          - babel-eslint@10.0.2
   - repo: https://github.com/prettier/prettier
     rev: 1.18.2
     hooks:
       - id: prettier
-  - repo: https://github.com/awebdeveloper/pre-commit-stylelint
-    rev: c4c991cd38b0218735858716b09924f8b20e3812
-    hooks:
-      - id: stylelint
-        additional_dependencies:
-          - stylelint@10.1.0
-          - stylelint-config-torchbox@0.5.0
   - repo: https://github.com/Yelp/detect-secrets
     rev: v0.13.0
     hooks:


### PR DESCRIPTION
This project has no front-end code. The extra linters in .pre-commit-config.yaml were not necessary.

- StyleLint – removed
- ESLint – removed
- Prettier – kept for Markdown files