### PR TITLE
Drop Python 3.9 (EOL) and add CI testing for Django 5.2

### DIFF
--- a/.github/workflows/CI-tests.yml
+++ b/.github/workflows/CI-tests.yml
@@ -20,13 +20,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        django-version: ["4.2.16", "5.0.9", "5.1.2"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        django-version: ["4.2", "5.1", "5.2"]
         exclude:
           # Django too new
-          - django-version: "5.0.9"
+          - django-version: "5.1"
             python-version: "3.9"
-          - django-version: "5.1.2"
+          - django-version: "5.2"
             python-version: "3.9"
     steps:
       - uses: actions/checkout@v4
@@ -49,7 +49,7 @@ jobs:
         run: |
           poetry config virtualenvs.in-project true
           poetry remove django
-          poetry add django==${{ matrix.django-version }} --python ${{ matrix.python-version }}
+          poetry add "django~=${{ matrix.django-version }}" --python ${{ matrix.python-version }}
           poetry install
           poetry show django
 
@@ -58,13 +58,13 @@ jobs:
     needs: [build, lint]
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        django-version: ["4.2.16", "5.0.9", "5.1.2"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        django-version: ["4.2", "5.1", "5.2"]
         exclude:
           # Django too new
-          - django-version: "5.0.9"
+          - django-version: "5.1"
             python-version: "3.9"
-          - django-version: "5.1.2"
+          - django-version: "5.2"
             python-version: "3.9"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/CI-tests.yml
+++ b/.github/workflows/CI-tests.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python "3.9"
+      - name: Set up Python "3.10"
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - uses: pre-commit/action@v3.0.1
 
   build:

--- a/.github/workflows/CI-tests.yml
+++ b/.github/workflows/CI-tests.yml
@@ -22,6 +22,13 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         django-version: ["4.2", "5.1", "5.2"]
+        exclude:
+          - python-version: "3.13"
+            django-version: "4.2"
+          - python-version: "3.14"
+            django-version: "4.2"
+          - python-version: "3.14"
+            django-version: "5.1"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -54,6 +61,13 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         django-version: ["4.2", "5.1", "5.2"]
+        exclude:
+          - python-version: "3.13"
+            django-version: "4.2"
+          - python-version: "3.14"
+            django-version: "4.2"
+          - python-version: "3.14"
+            django-version: "5.1"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/CI-tests.yml
+++ b/.github/workflows/CI-tests.yml
@@ -20,14 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         django-version: ["4.2", "5.1", "5.2"]
-        exclude:
-          # Django too new
-          - django-version: "5.1"
-            python-version: "3.9"
-          - django-version: "5.2"
-            python-version: "3.9"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -58,14 +52,8 @@ jobs:
     needs: [build, lint]
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         django-version: ["4.2", "5.1", "5.2"]
-        exclude:
-          # Django too new
-          - django-version: "5.1"
-            python-version: "3.9"
-          - django-version: "5.2"
-            python-version: "3.9"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/CI-tests.yml
+++ b/.github/workflows/CI-tests.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         django-version: ["4.2.16", "5.0.9", "5.1.2"]
         exclude:
           # Django too new
@@ -58,7 +58,7 @@ jobs:
     needs: [build, lint]
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         django-version: ["4.2.16", "5.0.9", "5.1.2"]
         exclude:
           # Django too new

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,19 @@
 repos:
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 8.0.1
     hooks:
       - id: isort
-        language_version: python3.9
+        language_version: python3.12
   - repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
+    rev: 7.3.0
     hooks:
       - id: flake8
-        language_version: python3.9
-  - repo: https://github.com/python/black
-    rev: 23.10.1
+        language_version: python3.12
+  - repo: https://github.com/psf/black
+    rev: 26.1.0
     hooks:
       - id: black
-        language_version: python3.9
+        language_version: python3.12
   - repo: https://github.com/prettier/prettier
     rev: 1.18.2
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Drop support for Python 3.9
+- Revise django version support to include Django 5.1 and 5.2
+- Drop support for Django 5.0
+
 ## 0.6.0 (2024-10-25)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Drop support for Python 3.9
 - Revise django version support to include Django 5.1 and 5.2
 - Drop support for Django 5.0
+- Upgrade pre-commit hooks
 
 ## 0.6.0 (2024-10-25)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,14 +22,13 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 license = "BSD-2-Clause"
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.13"
-django = [
-    {version = ">=4.2", python = ">=3.9,<3.13"},
-]
+python = ">=3.9"
+django = ">=4.2"
 notifications-python-client = "^8.1.0"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,14 +15,15 @@ classifiers = [
     "Topic :: Communications :: Email",
     "Framework :: Django",
     "Framework :: Django :: 4.2",
-    "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 license = "BSD-2-Clause"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
     "Framework :: Django :: 5.1",
     "Framework :: Django :: 5.2",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -28,7 +27,7 @@ classifiers = [
 license = "BSD-2-Clause"
 
 [tool.poetry.dependencies]
-python = ">=3.9"
+python = ">=3.10"
 django = ">=4.2"
 notifications-python-client = "^8.1.0"
 


### PR DESCRIPTION
## Summary

Python 3.9 reached end of life on 5 October 2025 and is no longer receiving security updates.

- Remove Python 3.9 from the CI matrix (build and test jobs)
- Modify the exclude: blocks in CI matrix
- Bump the python lower bound in pyproject.toml from >=3.9 to >=3.10
- Remove the Programming Language :: Python :: 3.9 PyPI classifier
- Upgrade pre-commit hooks

The CI matrix now has no exclusions.

---

Update by @nimasmi

Closes #15